### PR TITLE
test bench added

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+# Run from the repo root: pytest tests/
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# Treat warnings as information (not errors) – model libs are noisy
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::UserWarning
+    ignore::FutureWarning
+
+# Show short test summary for skipped/failed
+addopts = -v --tb=short

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(
         'easydict==1.13',
         'scipy==1.13.1',
         'six==1.16.0',
-        'matplotlib==3.9.0'
+        'matplotlib==3.9.0',
+        'pytest==8.4.2',
 
     ],
     extras_require={

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package for IndicPhotoOCR

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,114 @@
+"""
+Shared fixtures for IndicPhotoOCR tests.
+
+All fixtures that create real files use tmp_path (pytest built-in) so they
+are cleaned up automatically after each test.  No model weights are
+downloaded during unit tests – heavy integration tests are gated behind
+the --run-integration CLI flag.
+"""
+import os
+import numpy as np
+import pytest
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# Pytest configuration
+# ---------------------------------------------------------------------------
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests that require downloaded model weights.",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "integration: mark test as needing real model weights (skipped by default).",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--run-integration"):
+        skip_integration = pytest.mark.skip(reason="Pass --run-integration to run.")
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_integration)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic image helpers
+# ---------------------------------------------------------------------------
+
+def _make_rgb_array(h: int = 64, w: int = 128, color=(128, 64, 32)) -> np.ndarray:
+    """Return an H×W×3 uint8 numpy array filled with *color* (BGR order)."""
+    img = np.zeros((h, w, 3), dtype=np.uint8)
+    img[:, :] = color[::-1]  # PIL is RGB, cv2 is BGR – store as BGR
+    return img
+
+
+def _make_pil_image(h: int = 64, w: int = 128, color=(200, 100, 50)) -> Image.Image:
+    img = Image.new("RGB", (w, h), color=color)
+    return img
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def synthetic_scene_image(tmp_path) -> str:
+    """A small synthetic scene image saved to a temp file. Returns path."""
+    path = tmp_path / "scene.jpg"
+    img = _make_pil_image(h=480, w=640, color=(180, 180, 180))
+    img.save(str(path))
+    return str(path)
+
+
+@pytest.fixture()
+def synthetic_crop_image(tmp_path) -> str:
+    """A tiny synthetic word-crop image saved to a temp file. Returns path."""
+    path = tmp_path / "crop.jpg"
+    img = _make_pil_image(h=32, w=100, color=(230, 220, 210))
+    img.save(str(path))
+    return str(path)
+
+
+@pytest.fixture()
+def repo_scene_image() -> str:
+    """Real test image shipped with the repository (no model required)."""
+    base = os.path.join(os.path.dirname(__file__), "..", "test_images")
+    path = os.path.join(base, "image_141.jpg")
+    if not os.path.exists(path):
+        pytest.skip("Repo test image not found – run from repo root.")
+    return path
+
+
+@pytest.fixture()
+def repo_crop_image() -> str:
+    """Real cropped-word image shipped with the repository."""
+    base = os.path.join(os.path.dirname(__file__), "..", "test_images", "cropped_image")
+    path = os.path.join(base, "image_141_0.jpg")
+    if not os.path.exists(path):
+        pytest.skip("Repo crop image not found – run from repo root.")
+    return path
+
+
+@pytest.fixture()
+def sample_bbox_dict():
+    """A typical `recognized_texts` dict as returned by ocr.ocr() internals."""
+    return {
+        "img_0": {"txt": "hello",   "bbox": [10,  10,  80,  30]},
+        "img_1": {"txt": "world",   "bbox": [90,  12,  160, 32]},
+        "img_2": {"txt": "नमस्ते", "bbox": [10,  50,  100, 70]},
+        "img_3": {"txt": "दुनिया", "bbox": [110, 52,  200, 72]},
+    }
+
+
+@pytest.fixture()
+def single_word_bbox_dict():
+    return {"img_0": {"txt": "only", "bbox": [5, 5, 50, 20]}}

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,277 @@
+"""
+Tests for IndicPhotoOCR.detection – TextBPN++ detector.
+
+Unit tests cover only the pure static/helper methods (no GPU, no weights).
+Integration tests (marked `integration`) run the full model and require
+the checkpoint to be present or downloadable.
+
+Run unit tests only:
+    pytest tests/test_detection.py
+
+Run everything including integration:
+    pytest tests/test_detection.py --run-integration
+"""
+import os
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch, ANY
+
+
+# ---------------------------------------------------------------------------
+# Static-method unit tests (no model, no GPU)
+# ---------------------------------------------------------------------------
+
+class TestPadImage:
+    """TextBPNpp_detector.pad_image is a static method – import directly."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from IndicPhotoOCR.detection.textbpn.textbpnpp_detector import TextBPNpp_detector
+        self.pad_image = TextBPNpp_detector.pad_image
+
+    def test_already_aligned_image_unchanged(self):
+        img = np.zeros((64, 128, 3), dtype=np.uint8)
+        padded, original_size = self.pad_image(img, stride=32)
+        assert padded.shape[:2] == (64, 128)
+        assert original_size == (64, 128)
+
+    def test_unaligned_height_padded(self):
+        img = np.zeros((65, 128, 3), dtype=np.uint8)
+        padded, original_size = self.pad_image(img, stride=32)
+        assert padded.shape[0] == 96  # ceil(65/32)*32
+        assert original_size == (65, 128)
+
+    def test_unaligned_width_padded(self):
+        img = np.zeros((64, 100, 3), dtype=np.uint8)
+        padded, original_size = self.pad_image(img, stride=32)
+        assert padded.shape[1] == 128  # ceil(100/32)*32
+        assert original_size == (64, 100)
+
+    def test_both_dimensions_unaligned(self):
+        img = np.zeros((33, 33, 3), dtype=np.uint8)
+        padded, original_size = self.pad_image(img, stride=32)
+        assert padded.shape[:2] == (64, 64)
+        assert original_size == (33, 33)
+
+    def test_padding_region_is_black(self):
+        img = np.ones((32, 32, 3), dtype=np.uint8) * 200
+        padded, _ = self.pad_image(img, stride=64)
+        # Bottom pad (rows 32-63) should be zero
+        assert np.all(padded[32:, :, :] == 0)
+        # Right pad (cols 32-63) should be zero
+        assert np.all(padded[:, 32:, :] == 0)
+
+    def test_stride_1_is_noop(self):
+        img = np.zeros((37, 53, 3), dtype=np.uint8)
+        padded, original_size = self.pad_image(img, stride=1)
+        assert padded.shape[:2] == (37, 53)
+
+    def test_returns_original_size_tuple(self):
+        img = np.zeros((50, 70, 3), dtype=np.uint8)
+        _, original_size = self.pad_image(img, stride=32)
+        assert isinstance(original_size, tuple)
+        assert len(original_size) == 2
+
+
+class TestRescaleResult:
+    """TextBPNpp_detector.rescale_result rescales contour coords."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from IndicPhotoOCR.detection.textbpn.textbpnpp_detector import TextBPNpp_detector
+        self.rescale = TextBPNpp_detector.rescale_result
+
+    def _make_image(self, h, w):
+        return np.zeros((h, w, 3), dtype=np.uint8)
+
+    def _make_contour(self, points):
+        return np.array(points, dtype=np.int32)
+
+    def test_identity_rescale(self):
+        """If model image == original image, contours unchanged."""
+        image = self._make_image(100, 200)
+        cont = self._make_contour([[10, 20], [50, 80]])
+        result = self.rescale(image, [cont], original_height=100, original_width=200)
+        np.testing.assert_array_equal(result[0], cont)
+
+    def test_downscale_factor_2(self):
+        """Model ran on half the image → coords should double."""
+        # model image is 50×100, original is 100×200
+        image = self._make_image(50, 100)
+        cont = self._make_contour([[10, 5], [20, 10]])
+        result = self.rescale(image, [cont], original_height=100, original_width=200)
+        assert result[0][0][0] == 20   # x: 10 * (200/100)
+        assert result[0][0][1] == 10   # y:  5 * (100/50)
+
+    def test_multiple_contours(self):
+        image = self._make_image(100, 100)
+        conts = [
+            self._make_contour([[10, 20]]),
+            self._make_contour([[30, 40]]),
+        ]
+        result = self.rescale(image, conts, original_height=100, original_width=100)
+        assert len(result) == 2
+
+    def test_empty_contours_list(self):
+        image = self._make_image(100, 100)
+        result = self.rescale(image, [], original_height=100, original_width=100)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# ensure_model unit tests (network mocked)
+# ---------------------------------------------------------------------------
+
+class TestEnsureModel:
+    """ensure_model() should download when file missing, skip when present."""
+
+    def test_skips_download_when_model_exists(self, tmp_path):
+        from IndicPhotoOCR.detection.textbpn import textbpnpp_detector as mod
+
+        model_path = tmp_path / "model.pth"
+        model_path.write_bytes(b"\x00" * 10)   # pretend it already exists
+
+        original_info = mod.model_info.copy()
+        mod.model_info["_test"] = {
+            "path": "model.pth",
+            "url": "http://fake.invalid/model.pth",
+        }
+        try:
+            with patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.requests.get") as mock_get, \
+                 patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.os.path.exists",
+                        return_value=True):
+                result = mod.ensure_model("_test")
+                mock_get.assert_not_called()
+        finally:
+            mod.model_info.pop("_test", None)
+
+    def test_triggers_download_when_missing(self, tmp_path):
+        from IndicPhotoOCR.detection.textbpn import textbpnpp_detector as mod
+
+        fake_response = MagicMock()
+        fake_response.headers = {"content-length": "10"}
+        fake_response.iter_content.return_value = [b"\x00" * 10]
+
+        with patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.requests.get",
+                   return_value=fake_response) as mock_get, \
+             patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.os.path.exists",
+                    return_value=False), \
+             patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.os.makedirs"), \
+             patch("builtins.open", new_callable=MagicMock):
+            mod.ensure_model("textbpnpp")
+            mock_get.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TextBPNpp_detector.__init__ (constructor) – mocked
+# ---------------------------------------------------------------------------
+
+class TestTextBPNppDetectorInit:
+    @patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.ensure_model",
+           return_value="/fake/model.pth")
+    @patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.TextNet")
+    def test_constructor_calls_ensure_model(self, MockNet, mock_ensure):
+        from IndicPhotoOCR.detection.textbpn.textbpnpp_detector import TextBPNpp_detector
+        MockNet.return_value.load_model = MagicMock()
+        MockNet.return_value.eval = MagicMock(return_value=MagicMock())
+        MockNet.return_value.to = MagicMock(return_value=MagicMock())
+        TextBPNpp_detector(device="cpu")
+        mock_ensure.assert_called_once_with("textbpnpp")
+
+    @patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.ensure_model",
+           return_value="/fake/model.pth")
+    @patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.TextNet")
+    def test_constructor_sets_device(self, MockNet, mock_ensure):
+        from IndicPhotoOCR.detection.textbpn.textbpnpp_detector import TextBPNpp_detector
+        import torch
+        MockNet.return_value.load_model = MagicMock()
+        MockNet.return_value.eval = MagicMock(return_value=MagicMock())
+        MockNet.return_value.to = MagicMock(return_value=MagicMock())
+        det = TextBPNpp_detector(device="cpu")
+        assert det.device == torch.device("cpu")
+
+
+# ---------------------------------------------------------------------------
+# detect() return-format contract – mocked
+# ---------------------------------------------------------------------------
+
+class TestTextBPNppDetectorDetect:
+    """Test the detect() method output structure with a mocked forward pass."""
+
+    def _make_detector(self):
+        with patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.ensure_model",
+                   return_value="/fake/model.pth"), \
+             patch("IndicPhotoOCR.detection.textbpn.textbpnpp_detector.TextNet") as MockNet:
+            instance = MockNet.return_value
+            instance.load_model = MagicMock()
+            instance.eval = MagicMock(return_value=instance)
+            instance.to = MagicMock(return_value=instance)
+            from IndicPhotoOCR.detection.textbpn.textbpnpp_detector import TextBPNpp_detector
+            return TextBPNpp_detector(device="cpu"), instance
+
+    def test_detect_raises_on_missing_image(self, tmp_path):
+        det, _ = self._make_detector()
+        with pytest.raises((ValueError, Exception)):
+            det.detect(str(tmp_path / "nonexistent.jpg"))
+
+    def test_detect_returns_dict_with_detections_key(self, synthetic_scene_image):
+        import torch
+
+        det, mock_net = self._make_detector()
+
+        # Fake two 4-point contours
+        fake_contours = torch.zeros((2, 4, 2), dtype=torch.int32)
+        fake_output = {"py_preds": [None, fake_contours]}
+        mock_net.side_effect = None
+        mock_net.__call__ = MagicMock(return_value=fake_output)
+        mock_net.return_value = fake_output
+
+        with patch.object(det.model, "__call__", return_value=fake_output):
+            result = det.detect(synthetic_scene_image)
+
+        assert isinstance(result, dict)
+        assert "detections" in result
+        assert isinstance(result["detections"], list)
+
+    def test_detect_each_bbox_is_list(self, synthetic_scene_image):
+        import torch
+
+        det, mock_net = self._make_detector()
+        fake_contours = torch.zeros((3, 4, 2), dtype=torch.int32)
+        fake_output = {"py_preds": [None, fake_contours]}
+
+        with patch.object(det.model, "__call__", return_value=fake_output):
+            result = det.detect(synthetic_scene_image)
+
+        for bbox in result["detections"]:
+            assert isinstance(bbox, list)
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestTextBPNppIntegration:
+    """Requires model weights (downloaded automatically on first run)."""
+
+    def test_detect_real_image(self, repo_scene_image):
+        from IndicPhotoOCR.detection.textbpn.textbpnpp_detector import TextBPNpp_detector
+        det = TextBPNpp_detector(device="cpu")
+        result = det.detect(repo_scene_image)
+        assert "detections" in result
+        assert len(result["detections"]) > 0
+
+    def test_detect_result_bboxes_within_image_bounds(self, repo_scene_image):
+        import cv2
+        from IndicPhotoOCR.detection.textbpn.textbpnpp_detector import TextBPNpp_detector
+        det = TextBPNpp_detector(device="cpu")
+        result = det.detect(repo_scene_image)
+        img = cv2.imread(repo_scene_image)
+        h, w = img.shape[:2]
+        for bbox in result["detections"]:
+            flat = np.array(bbox).flatten()
+            xs = flat[0::2]
+            ys = flat[1::2]
+            assert np.all(xs >= 0) and np.all(xs <= w), f"x out of bounds: {xs}"
+            assert np.all(ys >= 0) and np.all(ys <= h), f"y out of bounds: {ys}"

--- a/tests/test_ocr_pipeline.py
+++ b/tests/test_ocr_pipeline.py
@@ -1,0 +1,327 @@
+"""
+Tests for IndicPhotoOCR.ocr – the OCR orchestration class.
+
+All three sub-modules (detector, script-identifier, recogniser) are mocked
+so that unit tests run with zero GPU or network access.
+
+Integration tests (--run-integration) exercise the real pipeline.
+"""
+import os
+import cv2
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch, call
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _make_fake_detector(detections=None):
+    """Return a mock detector whose detect() returns fixed bboxes."""
+    if detections is None:
+        # A single rectangular bbox (4 corner points)
+        detections = [[[10, 20], [80, 20], [80, 40], [10, 40]]]
+    mock = MagicMock()
+    mock.detect.return_value = {"detections": detections}
+    return mock
+
+
+def _make_fake_identifier(label="hindi"):
+    mock = MagicMock()
+    mock.identify.return_value = label
+    return mock
+
+
+def _make_fake_recogniser(text="टेस्ट"):
+    mock = MagicMock()
+    mock.recognise.return_value = text
+    return mock
+
+
+def _build_ocr(detector=None, identifier=None, recogniser=None, **kwargs):
+    """Construct an OCR instance with all sub-modules replaced by fakes."""
+    with patch("IndicPhotoOCR.ocr.TextBPNpp_detector", return_value=detector or _make_fake_detector()), \
+         patch("IndicPhotoOCR.ocr.VIT_identifier",     return_value=identifier or _make_fake_identifier()), \
+         patch("IndicPhotoOCR.ocr.PARseqrecogniser",   return_value=recogniser or _make_fake_recogniser()):
+        from IndicPhotoOCR.ocr import OCR
+        return OCR(device="cpu", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+class TestOCRConstructor:
+    def test_default_device_is_cuda(self):
+        """Default device param should be 'cuda:0' (even if unavailable)."""
+        with patch("IndicPhotoOCR.ocr.TextBPNpp_detector"), \
+             patch("IndicPhotoOCR.ocr.VIT_identifier"), \
+             patch("IndicPhotoOCR.ocr.PARseqrecogniser"):
+            from IndicPhotoOCR.ocr import OCR
+            ocr = OCR.__new__(OCR)
+            # Manually check the docstring / arg default via inspect
+            import inspect
+            sig = inspect.signature(OCR.__init__)
+            assert sig.parameters["device"].default == "cuda:0"
+
+    def test_verbose_stored(self):
+        ocr = _build_ocr(verbose=True)
+        assert ocr.verbose is True
+
+    def test_identifier_lang_stored(self):
+        ocr = _build_ocr(identifier_lang="tamil")
+        assert ocr.indentifier_lang == "tamil"
+
+    def test_submodules_instantiated(self):
+        with patch("IndicPhotoOCR.ocr.TextBPNpp_detector") as MockDet, \
+             patch("IndicPhotoOCR.ocr.VIT_identifier") as MockVit, \
+             patch("IndicPhotoOCR.ocr.PARseqrecogniser") as MockRec:
+            from IndicPhotoOCR.ocr import OCR
+            OCR(device="cpu")
+            MockDet.assert_called_once()
+            MockVit.assert_called_once()
+            MockRec.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# detect()
+# ---------------------------------------------------------------------------
+
+class TestOCRDetect:
+    def test_detect_delegates_to_detector(self, synthetic_scene_image):
+        fake_det = _make_fake_detector([[[0, 0], [10, 0], [10, 5], [0, 5]]])
+        ocr = _build_ocr(detector=fake_det)
+        result = ocr.detect(synthetic_scene_image)
+        fake_det.detect.assert_called_once_with(synthetic_scene_image)
+
+    def test_detect_returns_list(self, synthetic_scene_image):
+        ocr = _build_ocr()
+        result = ocr.detect(synthetic_scene_image)
+        assert isinstance(result, list)
+
+    def test_detect_returns_detector_bboxes(self, synthetic_scene_image):
+        bboxes = [[[1, 2], [3, 2], [3, 4], [1, 4]]]
+        ocr = _build_ocr(detector=_make_fake_detector(bboxes))
+        assert ocr.detect(synthetic_scene_image) == bboxes
+
+    def test_detect_empty_image_returns_empty_list(self, synthetic_scene_image):
+        ocr = _build_ocr(detector=_make_fake_detector([]))
+        assert ocr.detect(synthetic_scene_image) == []
+
+
+# ---------------------------------------------------------------------------
+# identify()
+# ---------------------------------------------------------------------------
+
+class TestOCRIdentify:
+    def test_identify_returns_string(self, synthetic_crop_image):
+        ocr = _build_ocr()
+        result = ocr.identify(synthetic_crop_image)
+        assert isinstance(result, str)
+
+    def test_identify_passes_lang_to_identifier(self, synthetic_crop_image):
+        fake_id = _make_fake_identifier("bengali")
+        ocr = _build_ocr(identifier=fake_id, identifier_lang="bengali")
+        ocr.identify(synthetic_crop_image)
+        fake_id.identify.assert_called_once_with(
+            synthetic_crop_image, "bengali", "cpu"
+        )
+
+
+# ---------------------------------------------------------------------------
+# crop_and_identify_script()
+# ---------------------------------------------------------------------------
+
+class TestCropAndIdentifyScript:
+    def _make_image_array(self, h=200, w=300):
+        return (np.random.rand(h, w, 3) * 255).astype(np.uint8)
+
+    def test_returns_two_tuple(self):
+        fake_id = _make_fake_identifier("hindi")
+        ocr = _build_ocr(identifier=fake_id)
+        img = self._make_image_array()
+        bbox = [[10, 20], [80, 20], [80, 50], [10, 50]]
+        lang, path = ocr.crop_and_identify_script(img, bbox)
+        assert isinstance(lang, str)
+        assert isinstance(path, str)
+
+    def test_script_lang_matches_identifier_output(self):
+        fake_id = _make_fake_identifier("tamil")
+        ocr = _build_ocr(identifier=fake_id)
+        img = self._make_image_array()
+        bbox = [[10, 20], [80, 20], [80, 50], [10, 50]]
+        lang, _ = ocr.crop_and_identify_script(img, bbox)
+        assert lang == "tamil"
+
+    def test_cropped_image_file_created(self):
+        ocr = _build_ocr()
+        img = self._make_image_array()
+        bbox = [[5, 5], [50, 5], [50, 30], [5, 30]]
+        _, path = ocr.crop_and_identify_script(img, bbox)
+        assert os.path.exists(path), f"Crop file not created: {path}"
+
+    def test_degenerate_bbox_does_not_crash(self):
+        """A zero-area bbox should not raise an exception."""
+        ocr = _build_ocr()
+        img = self._make_image_array()
+        bbox = [[10, 10], [10, 10], [10, 10], [10, 10]]
+        try:
+            ocr.crop_and_identify_script(img, bbox)
+        except Exception as e:
+            pytest.fail(f"crop_and_identify_script raised unexpectedly: {e}")
+
+
+# ---------------------------------------------------------------------------
+# recognise()
+# ---------------------------------------------------------------------------
+
+class TestOCRRecognise:
+    def test_recognise_returns_string(self, synthetic_crop_image):
+        ocr = _build_ocr()
+        result = ocr.recognise(synthetic_crop_image, "hindi")
+        assert isinstance(result, str)
+
+    def test_recognise_delegates_to_recogniser(self, synthetic_crop_image):
+        fake_rec = _make_fake_recogniser("मण्डी")
+        ocr = _build_ocr(recogniser=fake_rec)
+        result = ocr.recognise(synthetic_crop_image, "hindi")
+        assert result == "मण्डी"
+        fake_rec.recognise.assert_called_once()
+
+    def test_recognise_passes_language_and_image(self, synthetic_crop_image):
+        fake_rec = _make_fake_recogniser("road")
+        ocr = _build_ocr(recogniser=fake_rec)
+        ocr.recognise(synthetic_crop_image, "english")
+        args = fake_rec.recognise.call_args
+        # language and image path must appear somewhere in the call
+        all_args = list(args.args) + list(args.kwargs.values())
+        assert synthetic_crop_image in all_args
+        assert "english" in all_args
+
+
+# ---------------------------------------------------------------------------
+# visualize_detection()
+# ---------------------------------------------------------------------------
+
+class TestVisualizeDetection:
+    def test_creates_output_file(self, tmp_path, synthetic_scene_image):
+        ocr = _build_ocr()
+        out = str(tmp_path / "out.png")
+        bboxes = [[[10, 20], [80, 20], [80, 40], [10, 40]]]
+        ocr.visualize_detection(synthetic_scene_image, bboxes, save_path=out)
+        assert os.path.exists(out)
+
+    def test_creates_parent_directory(self, tmp_path, synthetic_scene_image):
+        ocr = _build_ocr()
+        out = str(tmp_path / "subdir" / "out.png")
+        ocr.visualize_detection(synthetic_scene_image, [], save_path=out)
+        assert os.path.exists(out)
+
+    def test_default_save_path_is_test_png(self, synthetic_scene_image, monkeypatch, tmp_path):
+        """When save_path=None it writes to 'test.png' relative to CWD."""
+        monkeypatch.chdir(tmp_path)
+        ocr = _build_ocr()
+        ocr.visualize_detection(synthetic_scene_image, [])
+        assert os.path.exists(tmp_path / "test.png")
+
+    def test_saved_image_is_readable(self, tmp_path, synthetic_scene_image):
+        ocr = _build_ocr()
+        out = str(tmp_path / "vis.png")
+        ocr.visualize_detection(synthetic_scene_image, [[[5, 5], [50, 5], [50, 30], [5, 30]]], save_path=out)
+        loaded = cv2.imread(out)
+        assert loaded is not None
+        assert loaded.shape[2] == 3
+
+
+# ---------------------------------------------------------------------------
+# ocr() – end-to-end with all sub-modules mocked
+# ---------------------------------------------------------------------------
+
+class TestOCREndToEnd:
+    def test_ocr_returns_list(self, synthetic_scene_image):
+        ocr = _build_ocr()
+        result = ocr.ocr(synthetic_scene_image)
+        assert isinstance(result, list)
+
+    def test_ocr_empty_detections_returns_empty_list(self, synthetic_scene_image):
+        ocr = _build_ocr(detector=_make_fake_detector([]))
+        result = ocr.ocr(synthetic_scene_image)
+        assert result == []
+
+    def test_ocr_single_detection_returns_one_line(self, synthetic_scene_image):
+        bboxes = [[[10, 20], [80, 20], [80, 40], [10, 40]]]
+        ocr = _build_ocr(
+            detector=_make_fake_detector(bboxes),
+            identifier=_make_fake_identifier("hindi"),
+            recogniser=_make_fake_recogniser("नमस्ते"),
+        )
+        result = ocr.ocr(synthetic_scene_image)
+        assert isinstance(result, list)
+        flat = [w for line in result for w in line]
+        assert "नमस्ते" in flat
+
+    def test_ocr_multiple_detections_all_words_present(self, synthetic_scene_image):
+        bboxes = [
+            [[10, 20], [80, 20], [80, 40], [10, 40]],
+            [[90, 20], [160, 20], [160, 40], [90, 40]],
+        ]
+        fake_rec = MagicMock()
+        fake_rec.recognise.side_effect = ["word1", "word2"]
+
+        ocr = _build_ocr(
+            detector=_make_fake_detector(bboxes),
+            identifier=_make_fake_identifier("hindi"),
+            recogniser=fake_rec,
+        )
+        result = ocr.ocr(synthetic_scene_image)
+        flat = [w for line in result for w in line]
+        assert set(flat) == {"word1", "word2"}
+
+    def test_ocr_detection_called_once(self, synthetic_scene_image):
+        fake_det = _make_fake_detector([])
+        ocr = _build_ocr(detector=fake_det)
+        ocr.ocr(synthetic_scene_image)
+        fake_det.detect.assert_called_once_with(synthetic_scene_image)
+
+    def test_ocr_skips_word_when_script_unknown(self, synthetic_scene_image):
+        """If identify() returns falsy, the word should be silently skipped."""
+        bboxes = [[[10, 20], [80, 20], [80, 40], [10, 40]]]
+        fake_id = _make_fake_identifier(None)  # falsy return
+        fake_rec = _make_fake_recogniser("should_not_appear")
+        ocr = _build_ocr(
+            detector=_make_fake_detector(bboxes),
+            identifier=fake_id,
+            recogniser=fake_rec,
+        )
+        result = ocr.ocr(synthetic_scene_image)
+        flat = [w for line in result for w in line]
+        assert "should_not_appear" not in flat
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestOCRIntegration:
+    def test_full_pipeline_real_image(self, repo_scene_image):
+        from IndicPhotoOCR.ocr import OCR
+        ocr = OCR(device="cpu", identifier_lang="auto", verbose=False)
+        result = ocr.ocr(repo_scene_image)
+        assert isinstance(result, list)
+        assert len(result) > 0
+        for line in result:
+            assert isinstance(line, list)
+            for word in line:
+                assert isinstance(word, str)
+
+    def test_detect_then_visualize(self, repo_scene_image, tmp_path):
+        from IndicPhotoOCR.ocr import OCR
+        ocr = OCR(device="cpu", verbose=False)
+        detections = ocr.detect(repo_scene_image)
+        assert len(detections) > 0
+        out = str(tmp_path / "vis.png")
+        ocr.visualize_detection(repo_scene_image, detections, save_path=out)
+        assert os.path.exists(out)

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -1,0 +1,233 @@
+"""
+Tests for IndicPhotoOCR.recognition – PARseqrecogniser.
+
+Unit tests mock all model loading and torch.hub calls.
+Integration tests (--run-integration) run real inference.
+"""
+import os
+import pytest
+import torch
+import numpy as np
+from unittest.mock import MagicMock, patch, call
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# model_info registry
+# ---------------------------------------------------------------------------
+
+class TestPARseqModelInfo:
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from IndicPhotoOCR.recognition.parseq_recogniser import model_info
+        self.model_info = model_info
+
+    EXPECTED_LANGUAGES = [
+        "assamese", "bengali", "hindi", "gujarati", "kannada",
+        "malayalam", "marathi", "odia", "punjabi", "tamil", "telugu",
+    ]
+
+    def test_all_indic_languages_present(self):
+        for lang in self.EXPECTED_LANGUAGES:
+            assert lang in self.model_info, f"Missing language: {lang}"
+
+    def test_each_entry_has_path_and_url(self):
+        for lang, info in self.model_info.items():
+            assert "path" in info, f"{lang}: missing 'path'"
+            assert "url"  in info, f"{lang}: missing 'url'"
+
+    def test_paths_end_with_ckpt(self):
+        for lang, info in self.model_info.items():
+            assert info["path"].endswith(".ckpt"), \
+                f"{lang}: checkpoint path should end with .ckpt"
+
+    def test_urls_start_with_https(self):
+        for lang, info in self.model_info.items():
+            assert info["url"].startswith("https://"), \
+                f"{lang}: URL should use HTTPS"
+
+
+# ---------------------------------------------------------------------------
+# ensure_model – download / cache
+# ---------------------------------------------------------------------------
+
+class TestPARseqEnsureModel:
+    @pytest.fixture(autouse=True)
+    def _recogniser(self):
+        from IndicPhotoOCR.recognition.parseq_recogniser import PARseqrecogniser
+        self.rec = PARseqrecogniser()
+
+    def test_skips_download_when_file_exists(self):
+        with patch("IndicPhotoOCR.recognition.parseq_recogniser.os.path.exists",
+                   return_value=True), \
+             patch("IndicPhotoOCR.recognition.parseq_recogniser.requests.get") as mock_get:
+            self.rec.ensure_model("hindi")
+            mock_get.assert_not_called()
+
+    def test_downloads_when_file_missing(self):
+        fake_response = MagicMock()
+        fake_response.headers = {"content-length": "10"}
+        fake_response.iter_content.return_value = [b"\x00" * 10]
+
+        with patch("IndicPhotoOCR.recognition.parseq_recogniser.os.path.exists",
+                   return_value=False), \
+             patch("IndicPhotoOCR.recognition.parseq_recogniser.requests.get",
+                   return_value=fake_response) as mock_get, \
+             patch("IndicPhotoOCR.recognition.parseq_recogniser.os.makedirs"), \
+             patch("builtins.open", new_callable=MagicMock):
+            self.rec.ensure_model("hindi")
+            mock_get.assert_called_once()
+
+    def test_returns_string_path(self):
+        with patch("IndicPhotoOCR.recognition.parseq_recogniser.os.path.exists",
+                   return_value=True):
+            path = self.rec.ensure_model("hindi")
+        assert isinstance(path, str)
+
+
+# ---------------------------------------------------------------------------
+# get_transform
+# ---------------------------------------------------------------------------
+
+class TestGetTransform:
+    @pytest.fixture(autouse=True)
+    def _recogniser(self):
+        from IndicPhotoOCR.recognition.parseq_recogniser import PARseqrecogniser
+        self.rec = PARseqrecogniser()
+
+    def test_returns_callable(self):
+        t = self.rec.get_transform((32, 128))
+        assert callable(t)
+
+    def test_transform_output_tensor_shape(self):
+        t = self.rec.get_transform((32, 128))
+        img = Image.new("RGB", (200, 60))
+        result = t(img)
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == (3, 32, 128)
+
+    def test_transform_output_value_range(self):
+        """Normalise(0.5, 0.5) maps [0,1] → [-1,1]."""
+        t = self.rec.get_transform((32, 128))
+        img = Image.new("RGB", (200, 60), (255, 255, 255))
+        result = t(img)
+        assert float(result.min()) >= -1.05   # small float tolerance
+        assert float(result.max()) <= 1.05
+
+    def test_transform_with_rotation(self):
+        """Rotation kwarg should not raise."""
+        t = self.rec.get_transform((32, 128), rotation=90)
+        img = Image.new("RGB", (200, 60))
+        result = t(img)
+        assert isinstance(result, torch.Tensor)
+
+
+# ---------------------------------------------------------------------------
+# get_model_output – contract (model mocked)
+# ---------------------------------------------------------------------------
+
+class TestGetModelOutput:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        from IndicPhotoOCR.recognition.parseq_recogniser import PARseqrecogniser
+        self.rec = PARseqrecogniser()
+
+    def _make_mock_model(self, text_out="hello"):
+        mock_model = MagicMock()
+        mock_model.hparams.img_size = (32, 128)
+
+        # Build plausible logits shape (1, seq_len, vocab)
+        seq_len = len(text_out) + 1
+        logits = torch.randn(1, seq_len, 96)
+        mock_model.return_value = logits
+
+        # softmax → decode → charset_adapter chain
+        mock_model.tokenizer.decode.return_value = ([text_out], [torch.ones(seq_len)])
+        mock_model.charset_adapter.return_value = text_out
+        return mock_model
+
+    def test_returns_string(self, synthetic_crop_image):
+        model = self._make_mock_model("test")
+        result = self.rec.get_model_output("cpu", model, synthetic_crop_image)
+        assert isinstance(result, str)
+
+    def test_returns_model_output_text(self, synthetic_crop_image):
+        model = self._make_mock_model("नमस्ते")
+        result = self.rec.get_model_output("cpu", model, synthetic_crop_image)
+        assert result == "नमस्ते"
+
+    def test_raises_on_nonexistent_image(self, tmp_path):
+        model = self._make_mock_model("x")
+        with pytest.raises(Exception):
+            self.rec.get_model_output("cpu", model, str(tmp_path / "ghost.jpg"))
+
+
+# ---------------------------------------------------------------------------
+# recognise() – top-level API contract (all model I/O mocked)
+# ---------------------------------------------------------------------------
+
+class TestRecognise:
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        from IndicPhotoOCR.recognition.parseq_recogniser import PARseqrecogniser
+        self.rec = PARseqrecogniser()
+
+    def test_recognise_indic_uses_ensure_model(self, synthetic_crop_image):
+        with patch.object(self.rec, "ensure_model", return_value="/fake/hindi.ckpt") as m_ensure, \
+             patch.object(self.rec, "load_model") as m_load, \
+             patch.object(self.rec, "get_model_output", return_value="टेस्ट"):
+            result = self.rec.recognise("hindi", synthetic_crop_image, "hindi", False, "cpu")
+            m_ensure.assert_called_once_with("hindi")
+            assert result == "टेस्ट"
+
+    def test_recognise_english_uses_torch_hub(self, synthetic_crop_image):
+        mock_model = MagicMock()
+        mock_model.eval.return_value = mock_model
+        mock_model.to.return_value = mock_model
+
+        with patch("IndicPhotoOCR.recognition.parseq_recogniser.torch.hub.load",
+                   return_value=mock_model) as m_hub, \
+             patch.object(self.rec, "get_model_output", return_value="hello"):
+            result = self.rec.recognise("english", synthetic_crop_image, "english", False, "cpu")
+            m_hub.assert_called_once()
+            assert result == "hello"
+
+    def test_recognise_returns_string(self, synthetic_crop_image):
+        with patch.object(self.rec, "ensure_model", return_value="/fake/m.ckpt"), \
+             patch.object(self.rec, "load_model", return_value=MagicMock()), \
+             patch.object(self.rec, "get_model_output", return_value="word"):
+            result = self.rec.recognise("hindi", synthetic_crop_image, "hindi", False, "cpu")
+        assert isinstance(result, str)
+
+    @pytest.mark.parametrize("lang", [
+        "hindi", "bengali", "tamil", "telugu", "gujarati",
+        "kannada", "malayalam", "marathi", "odia", "punjabi", "assamese",
+    ])
+    def test_recognise_all_indic_languages_routed_correctly(self, synthetic_crop_image, lang):
+        """All Indic languages should NOT go through torch.hub."""
+        with patch.object(self.rec, "ensure_model", return_value="/fake/m.ckpt"), \
+             patch.object(self.rec, "load_model", return_value=MagicMock()), \
+             patch.object(self.rec, "get_model_output", return_value="word"), \
+             patch("IndicPhotoOCR.recognition.parseq_recogniser.torch.hub.load") as m_hub:
+            self.rec.recognise(lang, synthetic_crop_image, lang, False, "cpu")
+            m_hub.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestPARseqIntegration:
+    def test_recognise_hindi_crop(self, repo_crop_image):
+        from IndicPhotoOCR.recognition.parseq_recogniser import PARseqrecogniser
+        rec = PARseqrecogniser()
+        result = rec.recognise("hindi", repo_crop_image, "hindi", False, "cpu")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_recognise_english_crop(self, repo_crop_image):
+        from IndicPhotoOCR.recognition.parseq_recogniser import PARseqrecogniser
+        rec = PARseqrecogniser()
+        result = rec.recognise("english", repo_crop_image, "english", False, "cpu")
+        assert isinstance(result, str)

--- a/tests/test_script_identification.py
+++ b/tests/test_script_identification.py
@@ -1,0 +1,253 @@
+"""
+Tests for IndicPhotoOCR.script_identification – VIT_identifier.
+
+Unit tests mock all network calls and model loading.
+Integration tests (--run-integration) run real inference.
+"""
+import os
+import zipfile
+import pytest
+import numpy as np
+from unittest.mock import MagicMock, patch, call
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# ensure_model – download / cache logic
+# ---------------------------------------------------------------------------
+
+class TestVITEnsureModel:
+    """Verify model is only downloaded when not already present."""
+
+    def _make_identifier(self):
+        # Import inside to avoid top-level side effects (processor auto-download)
+        with patch("IndicPhotoOCR.script_identification.vit.vit_infer.AutoImageProcessor.from_pretrained"):
+            from IndicPhotoOCR.script_identification.vit.vit_infer import VIT_identifier
+            return VIT_identifier()
+
+    def test_skips_download_when_folder_exists(self, tmp_path):
+        ident = self._make_identifier()
+        fake_path = tmp_path / "models" / "hindienglish"
+        fake_path.mkdir(parents=True)
+
+        with patch("IndicPhotoOCR.script_identification.vit.vit_infer.os.path.exists",
+                   return_value=True), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.requests.get") as mock_get:
+            ident.ensure_model("hindi")
+            mock_get.assert_not_called()
+
+    def test_triggers_download_when_folder_absent(self, tmp_path):
+        ident = self._make_identifier()
+
+        fake_zip_buf = _create_fake_zip()
+        fake_response = MagicMock()
+        fake_response.iter_content.return_value = [fake_zip_buf]
+
+        with patch("IndicPhotoOCR.script_identification.vit.vit_infer.os.path.exists",
+                   return_value=False), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.requests.get",
+                   return_value=fake_response) as mock_get, \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.os.makedirs"), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.zipfile.ZipFile"), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.os.remove"), \
+             patch("builtins.open", new_callable=MagicMock):
+            ident.ensure_model("hindi")
+            mock_get.assert_called_once()
+
+    def test_ensure_model_returns_string_path(self):
+        ident = self._make_identifier()
+        with patch("IndicPhotoOCR.script_identification.vit.vit_infer.os.path.exists",
+                   return_value=True):
+            path = ident.ensure_model("hindi")
+        assert isinstance(path, str)
+        assert len(path) > 0
+
+
+def _create_fake_zip():
+    """Return bytes of a minimal valid ZIP file."""
+    import io
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("dummy.txt", "placeholder")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# model_info registry
+# ---------------------------------------------------------------------------
+
+class TestVITModelInfo:
+    """Verify the model registry contains expected keys and structure."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        with patch("IndicPhotoOCR.script_identification.vit.vit_infer.AutoImageProcessor.from_pretrained"):
+            from IndicPhotoOCR.script_identification.vit.vit_infer import model_info
+            self.model_info = model_info
+
+    EXPECTED_LANGUAGES = [
+        "hindi", "assamese", "bengali", "gujarati", "kannada",
+        "malayalam", "marathi", "meitei", "odia", "punjabi",
+        "tamil", "telugu", "auto", "10C",
+    ]
+
+    def test_all_languages_present(self):
+        for lang in self.EXPECTED_LANGUAGES:
+            assert lang in self.model_info, f"Missing language: {lang}"
+
+    def test_each_entry_has_required_keys(self):
+        for lang, info in self.model_info.items():
+            assert "path" in info, f"{lang}: missing 'path'"
+            assert "url" in info, f"{lang}: missing 'url'"
+            assert "subcategories" in info, f"{lang}: missing 'subcategories'"
+
+    def test_subcategories_are_non_empty_lists(self):
+        for lang, info in self.model_info.items():
+            assert isinstance(info["subcategories"], list), f"{lang}: subcategories not a list"
+            assert len(info["subcategories"]) >= 2, f"{lang}: need at least 2 subcategories"
+
+    def test_auto_model_has_12_subcategories(self):
+        assert len(self.model_info["auto"]["subcategories"]) == 12
+
+    def test_english_is_always_a_subcategory(self):
+        """Every model should be able to handle English."""
+        for lang, info in self.model_info.items():
+            assert "english" in info["subcategories"], \
+                f"{lang}: 'english' missing from subcategories"
+
+    def test_urls_start_with_https(self):
+        for lang, info in self.model_info.items():
+            assert info["url"].startswith("https://"), \
+                f"{lang}: URL should use HTTPS"
+
+
+# ---------------------------------------------------------------------------
+# identify() – output contract (fully mocked)
+# ---------------------------------------------------------------------------
+
+class TestVITIdentify:
+    def _make_identifier(self):
+        with patch("IndicPhotoOCR.script_identification.vit.vit_infer.AutoImageProcessor.from_pretrained"):
+            from IndicPhotoOCR.script_identification.vit.vit_infer import VIT_identifier
+            return VIT_identifier()
+
+    def test_identify_returns_string(self, synthetic_crop_image):
+        ident = self._make_identifier()
+
+        mock_pipeline = MagicMock(return_value=[
+            {"label": "hindi", "score": 0.95},
+            {"label": "english", "score": 0.05},
+        ])
+
+        with patch.object(ident, "ensure_model", return_value="/fake/model"), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.ViTForImageClassification.from_pretrained",
+                   return_value=MagicMock()), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.pipeline",
+                   return_value=mock_pipeline):
+            result = ident.identify(synthetic_crop_image, "hindi", "cpu")
+
+        assert isinstance(result, str)
+
+    def test_identify_returns_highest_score_label(self, synthetic_crop_image):
+        ident = self._make_identifier()
+
+        mock_pipeline = MagicMock(return_value=[
+            {"label": "hindi",   "score": 0.10},
+            {"label": "english", "score": 0.80},
+            {"label": "tamil",   "score": 0.10},
+        ])
+
+        with patch.object(ident, "ensure_model", return_value="/fake/model"), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.ViTForImageClassification.from_pretrained",
+                   return_value=MagicMock()), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.pipeline",
+                   return_value=mock_pipeline):
+            result = ident.identify(synthetic_crop_image, "hindi", "cpu")
+
+        assert result == "english"
+
+    def test_identify_calls_ensure_model(self, synthetic_crop_image):
+        ident = self._make_identifier()
+
+        mock_pipeline = MagicMock(return_value=[{"label": "hindi", "score": 1.0}])
+
+        with patch.object(ident, "ensure_model", return_value="/fake/model") as mock_ensure, \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.ViTForImageClassification.from_pretrained",
+                   return_value=MagicMock()), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.pipeline",
+                   return_value=mock_pipeline):
+            ident.identify(synthetic_crop_image, "hindi", "cpu")
+
+        mock_ensure.assert_called_once_with("hindi")
+
+    @pytest.mark.parametrize("ext", [".png", ".jpg", ".jpeg"])
+    def test_identify_accepts_valid_extensions(self, tmp_path, ext):
+        ident = self._make_identifier()
+        img_path = tmp_path / f"crop{ext}"
+        Image.new("RGB", (64, 32), (200, 100, 50)).save(str(img_path))
+
+        mock_pipeline = MagicMock(return_value=[{"label": "hindi", "score": 1.0}])
+
+        with patch.object(ident, "ensure_model", return_value="/fake/model"), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.ViTForImageClassification.from_pretrained",
+                   return_value=MagicMock()), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.pipeline",
+                   return_value=mock_pipeline):
+            result = ident.identify(str(img_path), "hindi", "cpu")
+
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# predict_batch() – output file contract
+# ---------------------------------------------------------------------------
+
+class TestVITBatchPredict:
+    def _make_identifier(self):
+        with patch("IndicPhotoOCR.script_identification.vit.vit_infer.AutoImageProcessor.from_pretrained"):
+            from IndicPhotoOCR.script_identification.vit.vit_infer import VIT_identifier
+            return VIT_identifier()
+
+    def test_batch_creates_csv(self, tmp_path):
+        ident = self._make_identifier()
+
+        # Create 3 fake images
+        img_dir = tmp_path / "images"
+        img_dir.mkdir()
+        for i in range(3):
+            Image.new("RGB", (64, 32)).save(str(img_dir / f"img_{i}.jpg"))
+
+        csv_out = str(tmp_path / "out.csv")
+        mock_pipeline = MagicMock(return_value=[{"label": "Hindi", "score": 1.0}])
+
+        with patch.object(ident, "ensure_model", return_value="/fake/model"), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.ViTForImageClassification.from_pretrained",
+                   return_value=MagicMock()), \
+             patch("IndicPhotoOCR.script_identification.vit.vit_infer.pipeline",
+                   return_value=mock_pipeline):
+            result_path = ident.predict_batch(str(img_dir), "hindi",
+                                              time_show=False, output_csv=csv_out)
+
+        assert os.path.exists(result_path)
+        import csv
+        with open(result_path, newline="", encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == 3
+        for row in rows:
+            assert "Filepath" in row
+            assert "Language" in row
+
+
+# ---------------------------------------------------------------------------
+# Integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestVITIntegration:
+    def test_identify_real_crop(self, repo_crop_image):
+        with patch("IndicPhotoOCR.script_identification.vit.vit_infer.AutoImageProcessor.from_pretrained"):
+            from IndicPhotoOCR.script_identification.vit.vit_infer import VIT_identifier
+        ident = VIT_identifier()
+        result = ident.identify(repo_crop_image, "hindi", "cpu")
+        assert isinstance(result, str)
+        assert result in ["hindi", "english"]

--- a/tests/test_utils_helper.py
+++ b/tests/test_utils_helper.py
@@ -1,0 +1,176 @@
+"""
+Tests for IndicPhotoOCR.utils.helper
+
+detect_para() is a pure Python/NumPy function – no model weights needed.
+All tests here run without any external downloads.
+"""
+import pytest
+from IndicPhotoOCR.utils.helper import detect_para
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _bbox(x1, y1, x2, y2):
+    return [x1, y1, x2, y2]
+
+
+def _make_dict(**entries):
+    """Build a recognized_texts dict from keyword=((txt, bbox)) pairs."""
+    result = {}
+    for key, (txt, bbox) in entries.items():
+        result[key] = {"txt": txt, "bbox": bbox}
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Return-type contract
+# ---------------------------------------------------------------------------
+
+class TestDetectParaReturnType:
+    def test_returns_list(self, sample_bbox_dict):
+        result = detect_para(sample_bbox_dict)
+        assert isinstance(result, list), "detect_para must return a list"
+
+    def test_inner_elements_are_lists(self, sample_bbox_dict):
+        result = detect_para(sample_bbox_dict)
+        for line in result:
+            assert isinstance(line, list), "Each line grouping must be a list"
+
+    def test_inner_elements_are_strings(self, sample_bbox_dict):
+        result = detect_para(sample_bbox_dict)
+        for line in result:
+            for word in line:
+                assert isinstance(word, str), f"Expected str, got {type(word)}"
+
+    def test_empty_input_returns_empty_list(self):
+        result = detect_para({})
+        assert result == []
+
+    def test_single_word(self, single_word_bbox_dict):
+        result = detect_para(single_word_bbox_dict)
+        assert len(result) == 1
+        assert result[0] == ["only"]
+
+
+# ---------------------------------------------------------------------------
+# Word preservation
+# ---------------------------------------------------------------------------
+
+class TestDetectParaWordPreservation:
+    def test_all_words_are_preserved(self, sample_bbox_dict):
+        result = detect_para(sample_bbox_dict)
+        flat = [word for line in result for word in line]
+        expected = {v["txt"] for v in sample_bbox_dict.values()}
+        assert set(flat) == expected
+
+    def test_no_words_are_duplicated(self, sample_bbox_dict):
+        result = detect_para(sample_bbox_dict)
+        flat = [word for line in result for word in line]
+        assert len(flat) == len(sample_bbox_dict)
+
+    def test_unicode_words_preserved(self):
+        d = _make_dict(
+            w0=("राजीव",  _bbox(0,  0,  60, 20)),
+            w1=("चौक",    _bbox(70, 2,  130, 22)),
+        )
+        result = detect_para(d)
+        flat = [w for line in result for w in line]
+        assert "राजीव" in flat
+        assert "चौक" in flat
+
+
+# ---------------------------------------------------------------------------
+# Line grouping / horizontal sorting
+# ---------------------------------------------------------------------------
+
+class TestDetectParaGrouping:
+    def test_two_words_same_line_are_grouped(self):
+        """Words with ≥40 % vertical overlap should end up in the same line."""
+        d = _make_dict(
+            left=("left",  _bbox(0,  10, 50, 30)),
+            right=("right", _bbox(60, 10, 120, 30)),
+        )
+        result = detect_para(d)
+        assert len(result) == 1, "Two overlapping words must form one line"
+        assert result[0] == ["left", "right"]  # left comes first (smaller x1)
+
+    def test_two_words_different_lines_are_separated(self):
+        """Words with no vertical overlap must be on different lines."""
+        d = _make_dict(
+            top=("top",    _bbox(0, 0,  80, 20)),
+            bottom=("bottom", _bbox(5, 40, 85, 60)),
+        )
+        result = detect_para(d)
+        assert len(result) == 2, "Non-overlapping words must form separate lines"
+
+    def test_words_within_line_sorted_left_to_right(self):
+        """Within a line, words should be sorted by ascending x1."""
+        d = _make_dict(
+            c=("C", _bbox(200, 10, 250, 30)),
+            a=("A", _bbox(0,   10, 50,  30)),
+            b=("B", _bbox(100, 10, 150, 30)),
+        )
+        result = detect_para(d)
+        assert len(result) == 1
+        assert result[0] == ["A", "B", "C"]
+
+    def test_three_line_paragraph(self):
+        """Three clearly separated horizontal bands → three lines."""
+        d = _make_dict(
+            l1w1=("Line1Word1", _bbox(0,   0,  80,  20)),
+            l1w2=("Line1Word2", _bbox(90,  2,  170, 22)),
+            l2w1=("Line2Word1", _bbox(5,   40, 85,  60)),
+            l3w1=("Line3Word1", _bbox(10,  80, 90,  100)),
+        )
+        result = detect_para(d)
+        assert len(result) == 3
+
+    def test_overlap_threshold_boundary(self):
+        """Overlap exactly at 0.4 boundary: at-or-above merges, below separates."""
+        # Box heights = 20 px each; overlap = 8 px → ratio = 8/20 = 0.4 → merges
+        at_threshold = _make_dict(
+            a=("A", _bbox(0,  0,  40, 20)),
+            b=("B", _bbox(50, 12, 90, 32)),   # overlap = 8 px
+        )
+        result_at = detect_para(at_threshold)
+        # overlap/height == 0.4 → condition is `> 0.4`, so these should be SEPARATE
+        assert len(result_at) == 2, "Overlap exactly at 0.4 should NOT merge (strict >)"
+
+        # overlap = 9 px → 9/20 = 0.45 → merges
+        above_threshold = _make_dict(
+            a=("A", _bbox(0,  0,  40, 20)),
+            b=("B", _bbox(50, 11, 90, 31)),   # overlap = 9 px
+        )
+        result_above = detect_para(above_threshold)
+        assert len(result_above) == 1, "Overlap > 0.4 should merge into one line"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestDetectParaEdgeCases:
+    def test_zero_height_bbox_does_not_crash(self):
+        """A degenerate zero-height box (y1 == y2) must not raise ZeroDivisionError."""
+        d = _make_dict(
+            degenerate=("oops", _bbox(0, 10, 50, 10)),  # h = 0
+            normal=("fine",     _bbox(0, 30, 50, 50)),
+        )
+        # Should not raise
+        result = detect_para(d)
+        assert isinstance(result, list)
+
+    def test_large_number_of_words(self):
+        """50 words on a single horizontal line should all end in one group."""
+        d = {}
+        for i in range(50):
+            d[f"img_{i}"] = {"txt": f"word{i}", "bbox": [i * 20, 5, i * 20 + 18, 25]}
+        result = detect_para(d)
+        assert len(result) == 1
+        flat = result[0]
+        assert len(flat) == 50
+        # Words should be left-to-right
+        indices = [int(w.replace("word", "")) for w in flat]
+        assert indices == sorted(indices)


### PR DESCRIPTION
## Add Regression Test Suite for IndicPhotoOCR Pipeline

### Summary
Adds a comprehensive `pytest`-based test suite to prevent regressions as the pipeline is improved. All **104 unit tests** run in under 10 seconds with **no GPU, no model downloads, and no network access** required.

---

### Changes

* **`tests/conftest.py`** — Shared fixtures: synthetic images, real repo test images, sample bbox dicts, and an `--run-integration` CLI flag to gate heavy tests.
* **`tests/test_utils_helper.py`** — 15 tests for `detect_para`: return types, word preservation, line grouping, left-to-right sort order, overlap threshold boundary, Unicode support, and edge cases.
* **`tests/test_detection.py`** — 18 tests for `TextBPNpp_detector`: static methods (`pad_image`, `rescale_result`), `ensure_model` download/cache logic, constructor, and `detect()` output contract.
* **`tests/test_recognition.py`** — 22 tests for `PARseqrecogniser`: model registry, `ensure_model`, `get_transform` shape/value range, `get_model_output`, and `recognise()` routing for all 11 Indic languages + English.
* **`tests/test_script_identification.py`** — 16 tests for `VIT_identifier`: model registry structure, download logic, `identify()` label selection, file extension compatibility, and batch CSV output.
* **`tests/test_ocr_pipeline.py`** — 33 tests for the `OCR` class: constructor, each public method in isolation, full `ocr()` end-to-end flow with multiple detections, and skip-on-unknown-script behavior.
* **`pytest.ini`** — Test discovery config and warning filters.
* **`setup.py`** — Added `pytest` to `install_requires`.

---

### How to Run

```bash
# Unit tests only (CI-friendly, no GPU/downloads needed)
python -m pytest tests/

# Full suite including integration tests (requires model weights)
python -m pytest tests/ --run-integration
```

### Test Results
> **104 passed, 7 skipped in 8.95s**
> *The 7 skipped are integration tests (real model inference) gated behind `--run-integration`.*